### PR TITLE
More fixes for uk and au sites

### DIFF
--- a/ext/background.js
+++ b/ext/background.js
@@ -8,17 +8,18 @@ chrome.webRequest.onBeforeSendHeaders.addListener(details => {
     }
     return {requestHeaders: details.requestHeaders};
   }, {
-    urls: ['*://audible.com/*', '*://www.audible.com/*']
+    urls: ['*://www.audible.com/*', '*://www.audible.co.uk/*', '*://www.audible.com.au/*']
   },
   ['blocking', 'requestHeaders']);
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (tab.url.match(/audible\.com/i)) {
+  const url = new URL(tab.url);
+  if (['www.audible.com', 'www.audible.co.uk', 'www.audible.com.au'].includes(url.host)) {
     chrome.pageAction.show(tabId);
   }
 });
 
 chrome.pageAction.onClicked.addListener(tab => {
-  const domain = tab.url.match(/^[\w-]+:\/*\[?([\w\.:-]+)\]?(?::\d+)?/)[1];
-  chrome.tabs.update(tab.id, {url: `http://${domain}/legal-terms?audible=hero`});
+  const url = new URL(tab.url);
+  chrome.tabs.update(tab.id, {url: `${url.origin}/legal-terms?audible=hero`});
 });

--- a/src/components/Books.vue
+++ b/src/components/Books.vue
@@ -132,11 +132,11 @@
             </section>
             <section class="mdc-card__actions">
               <a class="mdc-button mdc-button--compact mdc-card__action" target="_blank"
-                 :href="`https://www.audible.com/pd/${book.id}`">
+                 :href="`/pd/${book.id}`">
                 Book
               </a>
               <a class="mdc-button mdc-button--compact mdc-card__action" target="_blank"
-                 :href="`https://www.audible.com/series?asin=${book.seriesId}`">
+                 :href="`/series?asin=${book.seriesId}`">
                 Series
               </a>
             </section>


### PR DESCRIPTION
1. Enable the Page Action icon on .uk and .au sites.
2. Make book links point to the current domain.