### PR TITLE
New library url

### DIFF
--- a/src/api/from-library.js
+++ b/src/api/from-library.js
@@ -1,6 +1,6 @@
 import { parse, getPageCount } from './parser';
 
-export default (limit, page) => fetch(`/lib?programFilter=all&purchaseDateFilter=all&pageSize=${limit}&page=${page}&sortBy=PURCHASE_DATE.dsc`, {
+export default (limit, page) => fetch(`/library/titles?programFilter=all&purchaseDateFilter=all&pageSize=${limit}&page=${page}&sortBy=PURCHASE_DATE.dsc`, {
   credentials: 'include'
 }).then(r =>
   r.text()
@@ -26,5 +26,5 @@ export default (limit, page) => fetch(`/lib?programFilter=all&purchaseDateFilter
 
   return { books, pageCount };
 }).catch(() => {
-  window.location.href = 'https://www.audible.com/lib';
+  window.location.href = '/library/titles';
 });


### PR DESCRIPTION
Audible changed the path to the library. They redirect from the old path, but all query parameters are stripped. The result is that only the first page of the library is ever read.

The same parameters and selectors seems to work for the new path, so the only thing that needs to change is the path.

Fixes #18 